### PR TITLE
replace case with simple if-then

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,7 @@ FROM registry.access.redhat.com/ubi8-minimal:8.1-398
 
 ARG KUBERNETES_VERSION=v1.17.3
 
-RUN case $(uname -m) in \
-       x86_64) ARCH="amd64" ;; \
-       ppc64le) ARCH="ppc64le" ;; \
-       s390x) ARCH="s390x";; \
-    esac && \
+RUN export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH="amd64"; fi && \
     microdnf install -y openssl && \
     cd /usr/local/bin && \
     curl -sLO https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/${ARCH}/kubectl && \


### PR DESCRIPTION
This is similar to this merged PR - https://github.com/eclipse/che-operator/pull/266 and validated this on `ppc64le` too.
```
$ docker build -t che-cert-manager-ca-cert-generator-image:latest .
Sending build context to Docker daemon  110.1kB
Step 1/5 : FROM registry.access.redhat.com/ubi8-minimal:8.1-398
 ---> eded1b7aaaf7
Step 2/5 : ARG KUBERNETES_VERSION=v1.17.3
 ---> Using cache
 ---> c0c6725eb6cd
Step 3/5 : RUN export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH="amd64"; fi &&     microdnf install -y openssl &&     cd /usr/local/bin &&     curl -sLO https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/${ARCH}/kubectl &&     chmod +x kubectl &&     microdnf clean all
 ---> Using cache
 ---> eb0e4e59c785
Step 4/5 : COPY entrypoint.sh /entrypoint.sh
 ---> Using cache
 ---> 49ad4d2ddd72
Step 5/5 : ENTRYPOINT ["/entrypoint.sh"]
 ---> Using cache
 ---> 6157513bedf0
Successfully built 6157513bedf0
Successfully tagged che-cert-manager-ca-cert-generator-image:latest

```

Signed-off-by: Amit Ghatwal ghatwala@us.ibm.com