### PR TITLE
Adding case for ARM too

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM registry.access.redhat.com/ubi8-minimal:8.1-398
 
 ARG KUBERNETES_VERSION=v1.17.3
 
-RUN export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH="amd64"; fi && \
+RUN export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH="amd64"; elif [[ ${ARCH} == "aarch64" ]]; then export ARCH="arm64"; fi && \
     microdnf install -y openssl && \
     cd /usr/local/bin && \
     curl -sLO https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/${ARCH}/kubectl && \


### PR DESCRIPTION
As suggested in review comment - https://github.com/che-dockerfiles/che-cert-manager-ca-cert-generator-image/pull/8#discussion_r431059297

Didn't have a ARM box , so again validated on power.
```
$ docker build -t che-cert-manager-ca-cert-generator-image:latest .
Sending build context to Docker daemon  116.7kB
Step 1/5 : FROM registry.access.redhat.com/ubi8-minimal:8.1-398
 ---> eded1b7aaaf7
Step 2/5 : ARG KUBERNETES_VERSION=v1.17.3
 ---> Using cache
 ---> c0c6725eb6cd
Step 3/5 : RUN export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH="amd64"; elif [[ ${ARCH} == "aarch64" ]]; then export ARCH="arm64"; fi &&     microdnf install -y openssl &&     cd /usr/local/bin &&     curl -sLO https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/${ARCH}/kubectl &&     chmod +x kubectl &&     microdnf clean all
 ---> Running in 8be7b04d49c5

(process:10): librhsm-WARNING **: 12:20:15.184: Found 0 entitlement certificates

(process:10): librhsm-WARNING **: 12:20:15.187: Found 0 entitlement certificates

(process:10): libdnf-WARNING **: 12:20:15.188: Loading "/etc/dnf/dnf.conf": IniParser: Can't open file
Downloading metadata...
Downloading metadata...
Downloading metadata...
Package                               Repository       Size
Installing:
 openssl-1:1.1.1c-15.el8.ppc64le      ubi-8-baseos 718.0 kB
 openssl-pkcs11-0.4.10-2.el8.ppc64le  ubi-8-baseos  73.0 kB
Upgrading:
 openssl-libs-1:1.1.1c-15.el8.ppc64le ubi-8-baseos   1.6 MB
Transaction Summary:
 Installing:        2 packages
 Reinstalling:      0 packages
 Upgrading:         1 packages
 Removing:          0 packages
 Downgrading:       0 packages
Downloading packages...
Running transaction test...
Updating: openssl-libs;1:1.1.1c-15.el8;ppc64le;ubi-8-baseos
Installing: openssl;1:1.1.1c-15.el8;ppc64le;ubi-8-baseos
Installing: openssl-pkcs11;0.4.10-2.el8;ppc64le;ubi-8-baseos
Installing: (null)
Cleanup: openssl-libs;1:1.1.1c-2.el8;ppc64le;installed
Installing: (null)
Installing: (null)
Complete.

(process:1): librhsm-WARNING **: 12:21:18.519: Found 0 entitlement certificates

(process:1): librhsm-WARNING **: 12:21:18.521: Found 0 entitlement certificates

(process:1): libdnf-WARNING **: 12:21:18.522: Loading "/etc/dnf/dnf.conf": IniParser: Can't open file
Complete.
Removing intermediate container 8be7b04d49c5
 ---> a509cd9366a6
Step 4/5 : COPY entrypoint.sh /entrypoint.sh
 ---> 2c5976914120
Step 5/5 : ENTRYPOINT ["/entrypoint.sh"]
 ---> Running in 7130be1d1bcf
Removing intermediate container 7130be1d1bcf
 ---> f8fa98854709
Successfully built f8fa98854709
Successfully tagged che-cert-manager-ca-cert-generator-image:latest
```
Signed-off-by: Amit Ghatwal ghatwala@us.ibm.com

Can you please review - @benoitf  ( ref : https://github.com/che-dockerfiles/che-cert-manager-ca-cert-generator-image/pull/8 )  and cc :  @mmorhun 